### PR TITLE
Add condition to chartArea which is only applicable to google chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "purdue-wp-theme",
-  "version": "1.5.6.3",
+  "version": "1.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "purdue-wp-theme",
-  "version": "1.5.6.3",
+  "version": "1.5.8",
   "description": "Purdue Wordpress Theme",
   "main": "index.js",
   "scripts": {

--- a/src/js/front-end/google-graph-spacing.js
+++ b/src/js/front-end/google-graph-spacing.js
@@ -1,10 +1,11 @@
 if(typeof(wpDataCharts)!=='undefined'){
     Object.keys(wpDataCharts).map(i => {
-        // set better sizing for all charts
-        wpDataCharts[i].render_data.options.chartArea.width = "70%"
-        wpDataCharts[i].render_data.options.chartArea.height = "85%"
-        wpDataCharts[i].render_data.options.chartArea.top = "0"
-
+        // set better sizing for all google charts
+        if(wpDataCharts[i].render_data.options.chartArea){
+            wpDataCharts[i].render_data.options.chartArea.width = "70%"
+            wpDataCharts[i].render_data.options.chartArea.height = "85%"
+            wpDataCharts[i].render_data.options.chartArea.top = "0"
+        }
         // set available colors for pie chart
         if (wpDataCharts[i].render_data.type === 'google_pie_chart') {
             wpDataCharts[i].render_data.options.chartArea.width = "100%"

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ in `Apperance > Themes`. Do not write in here any CSS declarations.
 Theme Name: Purdue Branded Theme
 Theme URI: https://marcom.purdue.edu/our-brand/digital/
 Description: WordPress theme based on Purdue University digital brand standards 
-Version: 1.5.7.2
+Version: 1.5.8
 Author: Purdue Marketing and Communicatons
 Author URI: https://marcom.purdue.edu
 Text Domain: purdue


### PR DESCRIPTION
The Google chart code throws an error when a different chart is added to the page using wpdatatables plugin. Version number was updated in order to build the files. 
Thanks!