### PR TITLE
Resolve "Button without a text alternative"

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -78,6 +78,7 @@
 	</div>
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
 		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/front-page.php
+++ b/front-page.php
@@ -16,6 +16,7 @@
 
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
 		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/home.php
+++ b/home.php
@@ -114,6 +114,7 @@
 	
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
 		<button id="to-top" class="to-top-hidden" aria-label="To top button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/index.php
+++ b/index.php
@@ -37,6 +37,7 @@
 
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
 		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/search.php
+++ b/search.php
@@ -70,7 +70,8 @@
 		</div>
 	</section>
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
-		<button id="to-top" class="to-top-hidden">
+		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/single-lndngpg.php
+++ b/single-lndngpg.php
@@ -23,7 +23,8 @@
 
 	?>
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
-		<button id="to-top" class="to-top-hidden">
+		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/single.php
+++ b/single.php
@@ -171,7 +171,8 @@ $incShare = get_theme_mod('social_setting',false);
 	</section>
 
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
-		<button id="to-top" class="to-top-hidden">
+		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>

--- a/template-doublesided.php
+++ b/template-doublesided.php
@@ -51,7 +51,8 @@
             </div>
         </section>
         <?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
-            <button id="to-top" class="to-top-hidden">
+            <button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
                 <i class="fas fa-chevron-up" aria-hidden="true"></i>
             </button>
         <?php } ?>

--- a/template-sidenav.php
+++ b/template-sidenav.php
@@ -37,7 +37,8 @@
 
 	?>
 	<?php if (!has_block('purdue-blocks/anchor-link-navigation')&&!has_block('purdue-blocks/custom-side-menu')) { ?>
-		<button id="to-top" class="to-top-hidden">
+		<button id="to-top" class="to-top-hidden" aria-label="Back to Top Button">
+			<span class="sr-only">Scroll back to the top of the page.</span>
 			<i class="fas fa-chevron-up" aria-hidden="true"></i>
 		</button>
 	<?php } ?>


### PR DESCRIPTION
- resolve Siteimprove issue, "Button without a text alternative", referencing the back to top button.
- https://my2.siteimprove.com/Accessibility/1034057/NextGen/Issue?ruleId=12&pageSegments=&issueKind=1&exceptTags=1,2&conformance=&siteGoal=
- add hidden text to the back to top button to describe its function.