### PR TITLE
home.php fatal error

### DIFF
--- a/home.php
+++ b/home.php
@@ -85,7 +85,7 @@
 									<div class="content-text">
 										<?php 
 											$more = true;
-											if(sizeof(the_excerpt())!==0){
+											if(strlen(the_excerpt())!==0){
 												the_excerpt();
 											}else{
 												echo purdue_get_excerpt(get_the_content()); 

--- a/search.php
+++ b/search.php
@@ -32,7 +32,7 @@
 								<p class="search-post-link"><?php the_permalink() ?></p>
 								<p  class="search-post-content">
 									<?php 					
-									if(sizeof(the_excerpt())!==0){
+									if(strlen(the_excerpt())!==0){
 										the_excerpt();
 									}else{
 										echo purdue_get_excerpt(get_the_content());


### PR DESCRIPTION
Hello - 

Home.php is throwing a fatal error in PHP8 because of improper usage of the sizeof function. Replaced sizeof with strlen to resolve the issue. 